### PR TITLE
Repro: dscale truncation corrupts values with stripped trailing zero groups

### DIFF
--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -148,6 +148,48 @@ public class NumericTests : MultiplexingTestBase
         }
     }
 
+    [Test, Description("Truncation must not corrupt values whose trailing zero digit groups were stripped from the wire format")]
+    public async Task Read_truncated_value_with_stripped_trailing_zero_groups()
+    {
+        // Postgres strips trailing zero base-10000 digit groups before sending, so a value's
+        // stored groups can end well before its display scale (dscale). 1::numeric(38,33) is
+        // transmitted as a single group [1] with dscale 33. Computing the groups to drop from
+        // dscale alone drops significant groups, or the whole value.
+        // A product of two numeric(28,20) columns has dscale 40, so every round-number
+        // rate/multiplier product takes this path.
+        using var conn = await OpenConnectionAsync();
+        using var cmd = new NpgsqlCommand(@"SELECT
+            1::numeric(38,33),
+            1::numeric(28,20) * 1::numeric(28,20) * 1::numeric(28,20),
+            0.5::numeric(28,20) * 1::numeric(28,20),
+            1.0000000001::numeric(28,20) * 1.0000000001::numeric(28,20)", conn);
+        using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+
+        Assert.That(reader.GetDecimal(0), Is.EqualTo(1m));
+        Assert.That(reader.GetDecimal(1), Is.EqualTo(1m));
+        Assert.That(reader.GetDecimal(2), Is.EqualTo(0.5m));
+        // 21 significant digits: fits in a decimal untruncated, so no digits may be lost.
+        Assert.That(reader.GetDecimal(3), Is.EqualTo(1.00000000020000000001m));
+    }
+
+    [Test, Description("Documents that overflow from total significant digits (rather than scale) is not covered by the dscale truncation")]
+    public async Task Read_overflow_from_total_width_still_throws()
+    {
+        // Scale 27 is under MaxDecimalScale, so the truncation branch never engages, but the
+        // 32 significant digits exceed decimal's 96-bit mantissa and the read still throws.
+        // This is the SUM(amount)-over-money shape from EZ-1204.
+        using var conn = await OpenConnectionAsync();
+        using var cmd = new NpgsqlCommand(@"SELECT 46320.903225806451612903225806448::numeric", conn);
+        using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+
+        Assert.That(() => reader.GetDecimal(0),
+            Throws.Exception
+                .With.TypeOf<OverflowException>()
+                .With.Message.EqualTo("Numeric value does not fit in a System.Decimal"));
+    }
+
     [Test]
     [TestCaseSource(nameof(ReadWriteCases))]
     public async Task Read_BigInteger(string query, decimal expected)


### PR DESCRIPTION
Repro tests for two issues with the dscale truncation in #6. Branched from and targeting `v7.0.10-decimal-overflows` so the failures show in context.

Postgres strips trailing zero digit groups from the binary wire format, so a value's stored groups can end well before its dscale. The patch computes the groups to drop from dscale alone, which drops significant groups, or the whole value. A product of two `numeric(28,20)` columns has dscale 40, so every round-number rate or multiplier product takes this path.

Results against postgres 15, stock 7.0.10 vs this PR's branch:

| query | stock 7.0.10 | patched | correct |
| --- | --- | --- | --- |
| `1::numeric(38,33)` | overflow | 0 | 1 |
| `1*1*1` as (28,20) product | overflow | 0 | 1 |
| `0.5*1` as (28,20) product | overflow | 0 | 0.5 |
| `1.0000000001^2` as (28,20) product | overflow | 1.0000000000000000000000000000 | 1.00000000020000000001 |
| EZ-1204 sum (scale 27, 32 sig digits) | overflow | overflow | 46320.9032258064516129032258064 |
| `Read_overflow_is_safe` constant (43 sig digits) | overflow | 0.2028571428571428571428571428 | ok |

Two tests added:

- `Read_truncated_value_with_stripped_trailing_zero_groups` fails on this branch (expected 1, got 0). That failure is the repro, not a broken test.
- `Read_overflow_from_total_width_still_throws` passes. It documents that the EZ-1204 SUM shape (32 significant digits at scale 27) still throws, since that overflow comes from total width rather than scale, so the SP chase isn't fully avoided by this approach.

To run: point `NPGSQL_TEST_DB` at any postgres and run the `NumericTests` fixture. The existing 464 tests in the fixture still pass.
