### PR TITLE
Round numerics wider than System.Decimal to the nearest representable value on read

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,12 @@ jobs:
         with:
           dotnet-version: ${{ env.dotnet_sdk_version }}
 
+      - name: Set version suffix for non-release branches
+        if: github.ref_name != 'billee-main'
+        run: echo "VERSION_SUFFIX_OVERRIDE=/p:VersionSuffix=${GITHUB_SHA::8}" >> $GITHUB_ENV
+
       - name: Pack
-        run: dotnet pack Npgsql.sln --configuration Release --output ${{ github.workspace }}/packages
+        run: dotnet pack Npgsql.sln --configuration Release --output ${{ github.workspace }}/packages ${{ env.VERSION_SUFFIX_OVERRIDE }}
 
       - name: Publish to GitHub Packages
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
     <VersionPrefix>7.0.10.2</VersionPrefix>
-    <VersionSuffix>pre</VersionSuffix>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>7.0.10.1</VersionPrefix>
+    <VersionPrefix>7.0.10.2</VersionPrefix>
+    <VersionSuffix>pre</VersionSuffix>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,12 +10,12 @@
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-    <PackageVersion Include="OpenTelemetry.API" Version="1.3.1" />
+    <PackageVersion Include="OpenTelemetry.API" Version="1.17.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
-    <PackageVersion Include="Scriban.Signed" Version="5.5.0 " />
+    <PackageVersion Include="Scriban.Signed" Version="7.2.6" />
 
     <!-- Plugins -->
     <PackageVersion Include="NetTopologySuite" Version="2.5.0" />

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Numerics;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
@@ -136,7 +137,7 @@ public partial class NumericHandler : NpgsqlTypeHandler<decimal>,
     // digits to text and hands them to decimal.Parse, which is exactly what the v2.x text
     // protocol did: round to the nearest representable decimal, throw OverflowException only
     // when the integer part alone cannot fit, i.e. |value| > decimal.MaxValue.
-    async ValueTask<decimal> ReadRounded(NpgsqlReadBuffer buf, bool async, short groups, int weight, bool negative, short scale)
+    static async ValueTask<decimal> ReadRounded(NpgsqlReadBuffer buf, bool async, short groups, int weight, bool negative, short scale)
     {
         await buf.Ensure(groups * sizeof(ushort), async);
 
@@ -155,33 +156,66 @@ public partial class NumericHandler : NpgsqlTypeHandler<decimal>,
         // The digits string is an integer equal to value / 10000^weight; place the decimal
         // point accordingly. weight >= 0 appends the missing zero groups; weight < 0 splits
         // the digits (padding with leading zeros when the value is a pure fraction).
-        var text = digits.ToString();
         var start = negative ? 1 : 0;
-        var digitCount = text.Length - start;
+        var digitCount = digits.Length - start;
         var pointShift = weight * MaxGroupScale;
         if (pointShift >= 0)
-            text += new string('0', pointShift);
+            digits.Append('0', pointShift);
         else if (-pointShift < digitCount)
-            text = text.Insert(text.Length + pointShift, ".");
+            digits.Insert(digits.Length + pointShift, ".");
         else
-            text = text.Insert(start, "0." + new string('0', -pointShift - digitCount));
+            digits.Insert(start, "0.").Insert(start + 2, "0", -pointShift - digitCount);
 
-        // Pad the fraction out to dscale (capped at decimal's max scale) so the parsed value
+        // Normalize the fraction out to dscale (capped at decimal's max scale) so the parsed value
         // keeps the same scale the v2.x text protocol produced from Postgres's rendering.
         var fraction = pointShift < 0 ? -pointShift : 0;
-        var pad = Math.Min((int)scale, MaxDecimalScale) - fraction;
-        if (pad > 0)
-            text = (fraction == 0 ? text + "." : text) + new string('0', pad);
+        NormalizeFractionalDigits(digits, fraction, scale);
 
         try
         {
-            return decimal.Parse(text, NumberStyles.Number, CultureInfo.InvariantCulture);
+            return decimal.Parse(digits.ToString(), NumberStyles.Number, CultureInfo.InvariantCulture);
         }
         catch (OverflowException)
         {
             // Keep the driver's historical message for callers and error grouping.
             throw new OverflowException("Numeric value does not fit in a System.Decimal");
         }
+    }
+
+    // Normalizes the fractional part of `digits` (currently `fractionDigits` digits long) to
+    // min(scale, MaxDecimalScale) digits, padding with trailing zeros as needed.
+    //
+    // Excess digits (fractionDigits > target) are only trimmed here when scale itself already fits
+    // a System.Decimal (scale <= MaxDecimalScale): in that case the excess is guaranteed to be zero
+    // padding from Postgres always transmitting whole 4-digit base-10000 groups, so a plain trim is
+    // exact. When scale exceeds MaxDecimalScale, the excess digits may be real precision rather than
+    // padding, so they are left in place for decimal.Parse to round (round-half-to-even), matching
+    // the v2.x text-protocol semantics instead of silently truncating significant digits ourselves.
+    static void NormalizeFractionalDigits(StringBuilder digits, int fractionDigits, short scale)
+    {
+        var target = Math.Min(scale, (short)MaxDecimalScale);
+        var padding = target - fractionDigits;
+
+        // target == fractionDigits: already exact
+        if (padding == 0) return;
+
+        if (padding > 0)
+        {
+            if (fractionDigits == 0)
+                digits.Append('.');
+
+            digits.Append('0', padding);
+            return;
+        }
+
+        // Scale > MaxDecimalScale: let decimal.Parse round
+        if (scale > MaxDecimalScale) return;
+
+        // scale <= MaxDecimalScale and fractionDigits > target: padding is the amount of guaranteed-zero padding to trim
+        var trimmedAmount = -padding;
+        digits.Remove(digits.Length - trimmedAmount, trimmedAmount);
+        if (target == 0 && digits[digits.Length - 1] == '.')
+            digits.Remove(digits.Length - 1, 1);
     }
 
     async ValueTask<byte> INpgsqlTypeHandler<byte>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
@@ -67,15 +67,27 @@ public partial class NumericHandler : NpgsqlTypeHandler<decimal>,
         var scale = buf.ReadInt16();
         if (scale < 0 is var exponential && exponential)
             scale = (short)(-scale);
-        else
-            result.Scale = scale;
-
-        if (scale > MaxDecimalScale)
-            throw new OverflowException("Numeric value does not fit in a System.Decimal");
 
         var scaleDifference = exponential
             ? weight * MaxGroupScale
             : weight * MaxGroupScale + scale;
+
+        // A value that may not fit a System.Decimal exactly is rounded to the nearest
+        // representable decimal instead of throwing, matching the v2.x text-protocol
+        // semantics of decimal.Parse. Only a value whose integer part cannot fit at any
+        // scale still throws. The last condition catches values whose coefficient
+        // (digit groups shifted up to the target scale) exceeds 28 digits even though
+        // the group count and dscale look small, e.g. trailing zero groups stripped
+        // from the wire below dscale, or large integers ending in zero groups.
+        if (!exponential && (scale > MaxDecimalScale || groups >= MaxGroupCount ||
+            scaleDifference > 0 && groups * MaxGroupScale + scaleDifference > MaxDecimalScale))
+            return await ReadRounded(buf, async, groups, weight, sign == SignNegative, scale);
+
+        if (!exponential)
+            result.Scale = scale;
+
+        if (scale > MaxDecimalScale)
+            throw new OverflowException("Numeric value does not fit in a System.Decimal");
 
         if (groups > MaxGroupCount)
             throw new OverflowException("Numeric value does not fit in a System.Decimal");
@@ -118,6 +130,56 @@ public partial class NumericHandler : NpgsqlTypeHandler<decimal>,
         }
 
         return result.Value;
+    }
+
+    static readonly BigInteger MaxDecimalCoefficient = new(decimal.MaxValue);
+
+    // Rounding path for values that may not fit a System.Decimal exactly. Accumulates the
+    // full wire value into a BigInteger, then reduces its scale with half-away-from-zero
+    // rounding (the same midpoint rule as Postgres round() and the write direction) until
+    // the coefficient fits decimal's 96-bit mantissa and 28-digit max scale. Throws only
+    // when the integer part alone cannot fit, i.e. |value| > decimal.MaxValue.
+    async ValueTask<decimal> ReadRounded(NpgsqlReadBuffer buf, bool async, short groups, int weight, bool negative, short scale)
+    {
+        await buf.Ensure(groups * sizeof(ushort), async);
+
+        var coefficient = BigInteger.Zero;
+        for (var i = 0; i < groups; i++)
+            coefficient = coefficient * MaxGroupSize + buf.ReadUInt16();
+
+        // value = coefficient * 10000^weight. Rebase so that value = coefficient / 10^effectiveScale.
+        var exponent = weight * MaxGroupScale + scale;
+        var effectiveScale = (int)scale;
+        if (exponent > 0)
+            coefficient *= BigInteger.Pow(10, exponent);
+        else
+            effectiveScale -= exponent;
+
+        // Rounding up can carry into an extra digit, so re-check the fit and drop further if needed.
+        var drop = Math.Max(effectiveScale - MaxDecimalScale, 0);
+        while (true)
+        {
+            var candidate = coefficient;
+            if (drop > 0)
+            {
+                var divisor = BigInteger.Pow(10, drop);
+                candidate = BigInteger.DivRem(coefficient, divisor, out var remainder);
+                if (remainder * 2 >= divisor)
+                    candidate += BigInteger.One;
+            }
+
+            if (candidate <= MaxDecimalCoefficient)
+                return new decimal(
+                    (int)(uint)(candidate & uint.MaxValue),
+                    (int)(uint)((candidate >> 32) & uint.MaxValue),
+                    (int)(uint)((candidate >> 64) & uint.MaxValue),
+                    negative,
+                    (byte)(effectiveScale - drop));
+
+            if (effectiveScale - drop == 0)
+                throw new OverflowException("Numeric value does not fit in a System.Decimal");
+            drop++;
+        }
     }
 
     async ValueTask<byte> INpgsqlTypeHandler<byte>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
@@ -132,53 +132,55 @@ public partial class NumericHandler : NpgsqlTypeHandler<decimal>,
         return result.Value;
     }
 
-    static readonly BigInteger MaxDecimalCoefficient = new(decimal.MaxValue);
-
-    // Rounding path for values that may not fit a System.Decimal exactly. Accumulates the
-    // full wire value into a BigInteger, then reduces its scale with half-away-from-zero
-    // rounding (the same midpoint rule as Postgres round() and the write direction) until
-    // the coefficient fits decimal's 96-bit mantissa and 28-digit max scale. Throws only
+    // Rounding path for values that may not fit a System.Decimal exactly. Renders the wire
+    // digits to text and hands them to decimal.Parse, which is exactly what the v2.x text
+    // protocol did: round to the nearest representable decimal, throw OverflowException only
     // when the integer part alone cannot fit, i.e. |value| > decimal.MaxValue.
     async ValueTask<decimal> ReadRounded(NpgsqlReadBuffer buf, bool async, short groups, int weight, bool negative, short scale)
     {
         await buf.Ensure(groups * sizeof(ushort), async);
 
-        var coefficient = BigInteger.Zero;
+        var digits = new System.Text.StringBuilder(groups * MaxGroupScale + MaxGroupScale + 2);
+        if (negative)
+            digits.Append('-');
         for (var i = 0; i < groups; i++)
-            coefficient = coefficient * MaxGroupSize + buf.ReadUInt16();
-
-        // value = coefficient * 10000^weight. Rebase so that value = coefficient / 10^effectiveScale.
-        var exponent = weight * MaxGroupScale + scale;
-        var effectiveScale = (int)scale;
-        if (exponent > 0)
-            coefficient *= BigInteger.Pow(10, exponent);
-        else
-            effectiveScale -= exponent;
-
-        // Rounding up can carry into an extra digit, so re-check the fit and drop further if needed.
-        var drop = Math.Max(effectiveScale - MaxDecimalScale, 0);
-        while (true)
         {
-            var candidate = coefficient;
-            if (drop > 0)
-            {
-                var divisor = BigInteger.Pow(10, drop);
-                candidate = BigInteger.DivRem(coefficient, divisor, out var remainder);
-                if (remainder * 2 >= divisor)
-                    candidate += BigInteger.One;
-            }
+            var group = buf.ReadUInt16();
+            if (i == 0)
+                digits.Append(group);
+            else
+                digits.Append(group.ToString("D4", CultureInfo.InvariantCulture));
+        }
 
-            if (candidate <= MaxDecimalCoefficient)
-                return new decimal(
-                    (int)(uint)(candidate & uint.MaxValue),
-                    (int)(uint)((candidate >> 32) & uint.MaxValue),
-                    (int)(uint)((candidate >> 64) & uint.MaxValue),
-                    negative,
-                    (byte)(effectiveScale - drop));
+        // The digits string is an integer equal to value / 10000^weight; place the decimal
+        // point accordingly. weight >= 0 appends the missing zero groups; weight < 0 splits
+        // the digits (padding with leading zeros when the value is a pure fraction).
+        var text = digits.ToString();
+        var start = negative ? 1 : 0;
+        var digitCount = text.Length - start;
+        var pointShift = weight * MaxGroupScale;
+        if (pointShift >= 0)
+            text += new string('0', pointShift);
+        else if (-pointShift < digitCount)
+            text = text.Insert(text.Length + pointShift, ".");
+        else
+            text = text.Insert(start, "0." + new string('0', -pointShift - digitCount));
 
-            if (effectiveScale - drop == 0)
-                throw new OverflowException("Numeric value does not fit in a System.Decimal");
-            drop++;
+        // Pad the fraction out to dscale (capped at decimal's max scale) so the parsed value
+        // keeps the same scale the v2.x text protocol produced from Postgres's rendering.
+        var fraction = pointShift < 0 ? -pointShift : 0;
+        var pad = Math.Min((int)scale, MaxDecimalScale) - fraction;
+        if (pad > 0)
+            text = (fraction == 0 ? text + "." : text) + new string('0', pad);
+
+        try
+        {
+            return decimal.Parse(text, NumberStyles.Number, CultureInfo.InvariantCulture);
+        }
+        catch (OverflowException)
+        {
+            // Keep the driver's historical message for callers and error grouping.
+            throw new OverflowException("Numeric value does not fit in a System.Decimal");
         }
     }
 

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -122,21 +122,21 @@ public class NumericTests : MultiplexingTestBase
         await AssertType(8M,       "8", "numeric", NpgsqlDbType.Numeric, DbType.Decimal, isDefault: false);
     }
 
-    [Test, Description("Tests that when Numeric value does not fit in a System.Decimal and reader is in ReaderState.InResult, the value was read wholly and it is safe to continue reading")]
+    [Test, Description("Tests that a numeric wider than a System.Decimal is rounded to the nearest representable value, the value is read wholly, and it is safe to continue reading")]
     public async Task Read_overflow_is_safe()
     {
         using var conn = await OpenConnectionAsync();
-        //This 29-digit number causes OverflowException. Here it is important to have unread column after failing one to leave it ReaderState.InResult
+        // This 29-digit number used to cause an OverflowException; it now rounds to 28 digits.
+        // The midpoint digit rounds away from zero, matching Postgres round() and the write direction.
+        // It is important to have an unread column after the wide one to prove the read consumed the
+        // whole value and the reader stays usable in ReaderState.InResult.
         using var cmd = new NpgsqlCommand(@"SELECT (0.20285714285714285714285714285)::numeric, generate_series FROM generate_series(1, 2)", conn);
         using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess);
         var i = 1;
 
         while (reader.Read())
         {
-            Assert.That(() => reader.GetDecimal(0),
-                Throws.Exception
-                    .With.TypeOf<OverflowException>()
-                    .With.Message.EqualTo("Numeric value does not fit in a System.Decimal"));
+            Assert.That(reader.GetDecimal(0), Is.EqualTo(0.2028571428571428571428571429m));
             var intValue = reader.GetInt32(1);
 
             Assert.That(intValue, Is.EqualTo(i++));
@@ -144,6 +144,68 @@ public class NumericTests : MultiplexingTestBase
             Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
             Assert.That(reader.State, Is.EqualTo(ReaderState.InResult));
         }
+    }
+
+    [Test, Description("High-dscale values whose trailing zero digit groups were stripped from the wire are read exactly, not corrupted")]
+    public async Task Read_high_dscale_value_with_stripped_trailing_zero_groups()
+    {
+        // Postgres strips trailing zero base-10000 digit groups before sending, so a value's
+        // stored groups can end well before its display scale. 1::numeric(38,33) is transmitted
+        // as a single group [1] with dscale 33. A product of two numeric(28,20) columns has
+        // dscale 40, so every round-number rate or multiplier product takes this shape.
+        using var conn = await OpenConnectionAsync();
+        using var cmd = new NpgsqlCommand(@"SELECT
+            1::numeric(38,33),
+            -1::numeric(38,33),
+            1::numeric(28,20) * 1::numeric(28,20) * 1::numeric(28,20),
+            0.5::numeric(28,20) * 1::numeric(28,20),
+            1.0000000001::numeric(28,20) * 1.0000000001::numeric(28,20)", conn);
+        using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+
+        Assert.That(reader.GetDecimal(0), Is.EqualTo(1m));
+        Assert.That(reader.GetDecimal(1), Is.EqualTo(-1m));
+        Assert.That(reader.GetDecimal(2), Is.EqualTo(1m));
+        Assert.That(reader.GetDecimal(3), Is.EqualTo(0.5m));
+        // 21 significant digits: fits in a decimal untouched, so no digits may be lost.
+        Assert.That(reader.GetDecimal(4), Is.EqualTo(1.00000000020000000001m));
+    }
+
+    [Test, Description("Overflow from total significant digits (rather than scale) rounds to the nearest representable decimal")]
+    public async Task Read_rounds_width_overflow_to_nearest_representable()
+    {
+        // 46320.903225806451612903225806448 is scale 27 but 32 significant digits: the overflow
+        // comes from total width, not dscale. It rounds to 29 digits, which fit.
+        // The 29 nines exercise carry propagation: rounding up adds a digit and the fit must be re-checked.
+        using var conn = await OpenConnectionAsync();
+        using var cmd = new NpgsqlCommand(@"SELECT
+            46320.903225806451612903225806448::numeric,
+            -46320.903225806451612903225806448::numeric,
+            0.99999999999999999999999999999::numeric", conn);
+        using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+
+        Assert.That(reader.GetDecimal(0), Is.EqualTo(46320.903225806451612903225806m));
+        Assert.That(reader.GetDecimal(1), Is.EqualTo(-46320.903225806451612903225806m));
+        Assert.That(reader.GetDecimal(2), Is.EqualTo(1m));
+    }
+
+    [Test, Description("A value whose integer part cannot fit in a decimal at any scale still throws")]
+    public async Task Read_integer_part_overflow_still_throws()
+    {
+        using var conn = await OpenConnectionAsync();
+        using var cmd = new NpgsqlCommand(@"SELECT 123456789012345678901234567890::numeric, 1e30::numeric", conn);
+        using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+
+        Assert.That(() => reader.GetDecimal(0),
+            Throws.Exception
+                .With.TypeOf<OverflowException>()
+                .With.Message.EqualTo("Numeric value does not fit in a System.Decimal"));
+        Assert.That(() => reader.GetDecimal(1),
+            Throws.Exception
+                .With.TypeOf<OverflowException>()
+                .With.Message.EqualTo("Numeric value does not fit in a System.Decimal"));
     }
 
     [Test]

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -126,17 +126,18 @@ public class NumericTests : MultiplexingTestBase
     public async Task Read_overflow_is_safe()
     {
         using var conn = await OpenConnectionAsync();
-        // This 29-digit number used to cause an OverflowException; it now rounds to 28 digits.
-        // The midpoint digit rounds away from zero, matching Postgres round() and the write direction.
-        // It is important to have an unread column after the wide one to prove the read consumed the
-        // whole value and the reader stays usable in ReaderState.InResult.
+        // This 29-digit number used to cause an OverflowException; it now rounds to 28 digits
+        // with decimal.Parse semantics, exactly as the v2.x text protocol did (the exact
+        // midpoint at digit 29 resolves to the truncated value under Parse's rounding).
+        // It is important to have an unread column after the wide one to prove the read consumed
+        // the whole value and the reader stays usable in ReaderState.InResult.
         using var cmd = new NpgsqlCommand(@"SELECT (0.20285714285714285714285714285)::numeric, generate_series FROM generate_series(1, 2)", conn);
         using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess);
         var i = 1;
 
         while (reader.Read())
         {
-            Assert.That(reader.GetDecimal(0), Is.EqualTo(0.2028571428571428571428571429m));
+            Assert.That(reader.GetDecimal(0), Is.EqualTo(0.2028571428571428571428571428m));
             var intValue = reader.GetInt32(1);
 
             Assert.That(intValue, Is.EqualTo(i++));

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -81,6 +81,30 @@ public class NumericTests : MultiplexingTestBase
         new object[] { "1234567844445555.000000000", 1234567844445555.000000000M },
         new object[] { "11112222000000000000", 11112222000000000000M },
         new object[] { "0::numeric", 0M },
+
+        // The following exercise NumericHandler.ReadRounded's fraction normalization: a wide-enough
+        // numeric routes through the rounding read path, which must reproduce the exact dscale Postgres
+        // reports rather than whatever scale the wire's base-10000 digit groups happen to render.
+
+        // Fraction shorter than dscale: no fractional groups are sent for a round-number cast to a
+        // wide numeric(_,3), so the read must pad with zeros to reach the requested scale.
+        new object[] { "12345678901234567890123456::numeric(30,3)", 12345678901234567890123456.000M },
+
+        // Fraction exactly matches dscale: no padding or trimming needed.
+        new object[] { "12345678901234567890123456.78::numeric", 12345678901234567890123456.78M },
+
+        // Fraction longer than dscale: Postgres always transmits whole 4-digit digit groups, so a
+        // dscale of 1 still renders a full trailing group (e.g. "5000"); the excess zeros within that
+        // group must be trimmed to match the real dscale exactly.
+        new object[] { "12345678901234567890123456.5::numeric(30,1)", 12345678901234567890123456.5M },
+
+        // dscale wider than System.Decimal can hold (> 28) is capped: the fraction is padded out to
+        // exactly 28 digits rather than the requested 30.
+        new object[] { "1::numeric(31,30)", 1.0000000000000000000000000000M },
+
+        new object[] { "-12345678901234567890123456.5::numeric(30,1)", -12345678901234567890123456.5M },
+        new object[] { "-12345678901234567890123456::numeric(30,3)", -12345678901234567890123456.000M },
+        new object[] { "12345678901234567890123456::numeric(30,0)", 12345678901234567890123456M },
     };
 
     [Test]


### PR DESCRIPTION
Alternative to #6. Any numeric that can't fit a System.Decimal is rounded to the nearest representable value with decimal.Parse semantics, which is bit-for-bit what the 2.2.7 text protocol did. That covers both overflow classes we've hit: high-dscale products of bounded columns (dscale 40 from numeric(28,20) arithmetic, the Metergy shape) and totals whose significant width exceeds 28-29 digits (the EZ-1204 SUM shape). It also avoids the stripped-trailing-zero-groups corruption shown in #7.

The rules:

1. A value that fits is read exactly, through the existing fast path, untouched.
2. A value that doesn't fit is rendered to text and read with decimal.Parse, which rounds to the nearest representable decimal.
3. Only a value whose integer part exceeds decimal.MaxValue still throws, since no scale can represent it. No billing value is legitimately there.

Implementation: the header check routes anything that might not fit to a path that renders the wire digit groups to a digit string and parses it. Per the Slack thread, this replaced an earlier BigInteger reduction for readability. The new code only runs where stock currently throws, so the worst case regression is in code that today doesn't work at all. One latent stock bug comes along for free: a fitting 28-digit value with 4-digit-aligned trailing zeros used to throw because the coefficient was scaled up before the fit check.

Results (postgres 15, stock vs this branch):

| query | stock 7.0.10 | this branch |
| --- | --- | --- |
| `1::numeric(38,33)` | overflow | 1 |
| `1*1*1` as (28,20) product | overflow | 1 |
| `0.5*1` as (28,20) product | overflow | 0.5 |
| `1.0000000001^2` as (28,20) product | overflow | 1.0000000002000000000100000000 (exact) |
| EZ-1204 sum (32 sig digits) | overflow | 46320.903225806451612903225806 |
| 29-digit `Read_overflow_is_safe` constant | overflow | 0.2028571428571428571428571428 |
| 32 sig digits at dscale 31 | overflow | 12345678.901234567890123456789 |
| 30-digit total with dscale 2 | overflow | 1234567890123456789012345678.9 |
| `123456789012345678901234567890::numeric` | overflow | overflow (integer part can't fit) |

The last three rows are the shapes where the v10-line clamp in #9 still throws or hits an IndexOutOfRangeException (details on that PR).

Tests: the full NumericTests fixture passes, 468/468 across both multiplexing modes, including the GetBits-exact read/write cases. Read_overflow_is_safe asserts the parsed value while still proving the reader stays usable mid-resultset. New tests cover the stripped-zero-groups shapes from #7, width overflow with rounding, carry propagation (29 nines round up to 1), and the integer-part throw.

Notes:

- First commit carries the same Scriban/OpenTelemetry bumps as #6. Those turn out to be required: Scriban 5.5.0 has advisories that current SDKs treat as build errors, so billee-main doesn't build without them. I was wrong to call them unrelated in #7.
- Values with 8+ digit groups now take the text path even when they fit. That's a small per-value allocation on rare wide values, negligible next to the round trip.
- Negative-dscale values (pg 14+ round(x, -n) results) keep stock behavior.
- This targets the 7.0.10 line because ez/ is net48 and the fork's main is net8.0-only. If upstream ever ships the npgsql/npgsql#6125 compatibility switch, this patch gets deleted in favor of it.
