### PR TITLE
V10 numeric overflows

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,26 +3,22 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="OpenTelemetry.API" Version="1.7.0" />
-
     <!-- Compatibility -->
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-
     <!-- Plugin projects -->
     <PackageVersion Include="NetTopologySuite" Version="2.5.0" />
     <PackageVersion Include="NetTopologySuite.IO.PostGIS" Version="2.1.0" />
     <PackageVersion Include="NodaTime" Version="3.2.0" />
     <PackageVersion Include="GeoJSON.Net" Version="1.4.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-
     <!-- Build -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Scriban.Signed" Version="5.9.0 " />
-    
+    <PackageVersion Include="Scriban.Signed" Version="7.2.6" />
     <!-- Tests -->
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
@@ -35,12 +31,10 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="AdoNet.Specification.Tests" Version="2.0.0-beta.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.10" />
-
     <!-- NativeAOT -->
     <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
   </ItemGroup>

--- a/src/Npgsql/Internal/Converters/Primitive/PgNumeric.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/PgNumeric.cs
@@ -301,8 +301,7 @@ readonly struct PgNumeric(ArraySegment<short> digits, short weight, short sign, 
             if (digitCount > MaxDecimalNumericDigits)
                 throw new OverflowException("Numeric value does not fit in a System.Decimal");
 
-            if (Math.Abs(scale) > MaxDecimalScale)
-                throw new OverflowException("Numeric value does not fit in a System.Decimal");
+            scale = scale > 0 ? Math.Min(scale, (short)MaxDecimalScale) : Math.Max(scale, (short)-MaxDecimalScale);
 
             var scaleFactor = new decimal(1, 0, 0, false, (byte)(scale > 0 ? scale : 0));
             if (digitCount == 0)

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -149,6 +149,48 @@ public class NumericTests(MultiplexingMode multiplexingMode) : MultiplexingTestB
         }
     }
 
+    [Test, Description("Truncation must not corrupt values whose trailing zero digit groups were stripped from the wire format")]
+    public async Task Read_truncated_value_with_stripped_trailing_zero_groups()
+    {
+        // Postgres strips trailing zero base-10000 digit groups before sending, so a value's
+        // stored groups can end well before its display scale (dscale). 1::numeric(38,33) is
+        // transmitted as a single group [1] with dscale 33. Computing the groups to drop from
+        // dscale alone drops significant groups, or the whole value.
+        // A product of two numeric(28,20) columns has dscale 40, so every round-number
+        // rate/multiplier product takes this path.
+        using var conn = await OpenConnectionAsync();
+        using var cmd = new NpgsqlCommand(@"SELECT
+            1::numeric(38,33),
+            1::numeric(28,20) * 1::numeric(28,20) * 1::numeric(28,20),
+            0.5::numeric(28,20) * 1::numeric(28,20),
+            1.0000000001::numeric(28,20) * 1.0000000001::numeric(28,20)", conn);
+        using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+
+        Assert.That(reader.GetDecimal(0), Is.EqualTo(1m));
+        Assert.That(reader.GetDecimal(1), Is.EqualTo(1m));
+        Assert.That(reader.GetDecimal(2), Is.EqualTo(0.5m));
+        // 21 significant digits: fits in a decimal untruncated, so no digits may be lost.
+        Assert.That(reader.GetDecimal(3), Is.EqualTo(1.00000000020000000001m));
+    }
+
+    [Test, Description("Documents that overflow from total significant digits (rather than scale) is not covered by the dscale truncation")]
+    public async Task Read_overflow_from_total_width_still_throws()
+    {
+        // Scale 27 is under MaxDecimalScale, so the truncation branch never engages, but the
+        // 32 significant digits exceed decimal's 96-bit mantissa and the read still throws.
+        // This is the SUM(amount)-over-money shape from EZ-1204.
+        using var conn = await OpenConnectionAsync();
+        using var cmd = new NpgsqlCommand(@"SELECT 46320.903225806451612903225806448::numeric", conn);
+        using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+
+        Assert.That(() => reader.GetDecimal(0),
+            Throws.Exception
+                .With.TypeOf<OverflowException>()
+                .With.Message.EqualTo("Numeric value does not fit in a System.Decimal"));
+    }
+
     [Test]
     [TestCaseSource(nameof(ReadWriteCases))]
     public async Task Read_BigInteger(string query, decimal expected)

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -136,10 +136,12 @@ public class NumericTests(MultiplexingMode multiplexingMode) : MultiplexingTestB
 
         while (reader.Read())
         {
-            Assert.That(() => reader.GetDecimal(0),
-                Throws.Exception
-                    .With.TypeOf<OverflowException>()
-                    .With.Message.EqualTo("Numeric value does not fit in a System.Decimal"));
+            var decimalValue = reader.GetDecimal(0);
+            Assert.That(decimalValue, Is.EqualTo(0.2028571428571428571428571428m));
+            // Assert.That(() => reader.GetDecimal(0),
+            //     Throws.Exception
+            //         .With.TypeOf<OverflowException>()
+            //         .With.Message.EqualTo("Numeric value does not fit in a System.Decimal"));
             var intValue = reader.GetInt32(1);
 
             Assert.That(intValue, Is.EqualTo(i++));


### PR DESCRIPTION
Same as the others, but against the newest version of Npgsql that our ~repo~ fork is synced against.