### PR TITLE
Normalize fractional digits in NumericHandler.ReadRounded 

### DIFF
--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Numerics;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
@@ -136,7 +137,7 @@ public partial class NumericHandler : NpgsqlTypeHandler<decimal>,
     // digits to text and hands them to decimal.Parse, which is exactly what the v2.x text
     // protocol did: round to the nearest representable decimal, throw OverflowException only
     // when the integer part alone cannot fit, i.e. |value| > decimal.MaxValue.
-    async ValueTask<decimal> ReadRounded(NpgsqlReadBuffer buf, bool async, short groups, int weight, bool negative, short scale)
+    static async ValueTask<decimal> ReadRounded(NpgsqlReadBuffer buf, bool async, short groups, int weight, bool negative, short scale)
     {
         await buf.Ensure(groups * sizeof(ushort), async);
 
@@ -155,33 +156,66 @@ public partial class NumericHandler : NpgsqlTypeHandler<decimal>,
         // The digits string is an integer equal to value / 10000^weight; place the decimal
         // point accordingly. weight >= 0 appends the missing zero groups; weight < 0 splits
         // the digits (padding with leading zeros when the value is a pure fraction).
-        var text = digits.ToString();
         var start = negative ? 1 : 0;
-        var digitCount = text.Length - start;
+        var digitCount = digits.Length - start;
         var pointShift = weight * MaxGroupScale;
         if (pointShift >= 0)
-            text += new string('0', pointShift);
+            digits.Append('0', pointShift);
         else if (-pointShift < digitCount)
-            text = text.Insert(text.Length + pointShift, ".");
+            digits.Insert(digits.Length + pointShift, ".");
         else
-            text = text.Insert(start, "0." + new string('0', -pointShift - digitCount));
+            digits.Insert(start, "0.").Insert(start + 2, "0", -pointShift - digitCount);
 
-        // Pad the fraction out to dscale (capped at decimal's max scale) so the parsed value
+        // Normalize the fraction out to dscale (capped at decimal's max scale) so the parsed value
         // keeps the same scale the v2.x text protocol produced from Postgres's rendering.
         var fraction = pointShift < 0 ? -pointShift : 0;
-        var pad = Math.Min((int)scale, MaxDecimalScale) - fraction;
-        if (pad > 0)
-            text = (fraction == 0 ? text + "." : text) + new string('0', pad);
+        NormalizeFractionalDigits(digits, fraction, scale);
 
         try
         {
-            return decimal.Parse(text, NumberStyles.Number, CultureInfo.InvariantCulture);
+            return decimal.Parse(digits.ToString(), NumberStyles.Number, CultureInfo.InvariantCulture);
         }
         catch (OverflowException)
         {
             // Keep the driver's historical message for callers and error grouping.
             throw new OverflowException("Numeric value does not fit in a System.Decimal");
         }
+    }
+
+    // Normalizes the fractional part of `digits` (currently `fractionDigits` digits long) to
+    // min(scale, MaxDecimalScale) digits, padding with trailing zeros as needed.
+    //
+    // Excess digits (fractionDigits > target) are only trimmed here when scale itself already fits
+    // a System.Decimal (scale <= MaxDecimalScale): in that case the excess is guaranteed to be zero
+    // padding from Postgres always transmitting whole 4-digit base-10000 groups, so a plain trim is
+    // exact. When scale exceeds MaxDecimalScale, the excess digits may be real precision rather than
+    // padding, so they are left in place for decimal.Parse to round (round-half-to-even), matching
+    // the v2.x text-protocol semantics instead of silently truncating significant digits ourselves.
+    static void NormalizeFractionalDigits(StringBuilder digits, int fractionDigits, short scale)
+    {
+        var target = Math.Min(scale, (short)MaxDecimalScale);
+        var padding = target - fractionDigits;
+
+        // target == fractionDigits: already exact
+        if (padding == 0) return;
+
+        if (padding > 0)
+        {
+            if (fractionDigits == 0)
+                digits.Append('.');
+
+            digits.Append('0', padding);
+            return;
+        }
+
+        // Scale > MaxDecimalScale: let decimal.Parse round
+        if (scale > MaxDecimalScale) return;
+
+        // scale <= MaxDecimalScale and fractionDigits > target: padding is the amount of guaranteed-zero padding to trim
+        var trimmedAmount = -padding;
+        digits.Remove(digits.Length - trimmedAmount, trimmedAmount);
+        if (target == 0 && digits[digits.Length - 1] == '.')
+            digits.Remove(digits.Length - 1, 1);
     }
 
     async ValueTask<byte> INpgsqlTypeHandler<byte>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -81,6 +81,30 @@ public class NumericTests : MultiplexingTestBase
         new object[] { "1234567844445555.000000000", 1234567844445555.000000000M },
         new object[] { "11112222000000000000", 11112222000000000000M },
         new object[] { "0::numeric", 0M },
+
+        // The following exercise NumericHandler.ReadRounded's fraction normalization: a wide-enough
+        // numeric routes through the rounding read path, which must reproduce the exact dscale Postgres
+        // reports rather than whatever scale the wire's base-10000 digit groups happen to render.
+
+        // Fraction shorter than dscale: no fractional groups are sent for a round-number cast to a
+        // wide numeric(_,3), so the read must pad with zeros to reach the requested scale.
+        new object[] { "12345678901234567890123456::numeric(30,3)", 12345678901234567890123456.000M },
+
+        // Fraction exactly matches dscale: no padding or trimming needed.
+        new object[] { "12345678901234567890123456.78::numeric", 12345678901234567890123456.78M },
+
+        // Fraction longer than dscale: Postgres always transmits whole 4-digit digit groups, so a
+        // dscale of 1 still renders a full trailing group (e.g. "5000"); the excess zeros within that
+        // group must be trimmed to match the real dscale exactly.
+        new object[] { "12345678901234567890123456.5::numeric(30,1)", 12345678901234567890123456.5M },
+
+        // dscale wider than System.Decimal can hold (> 28) is capped: the fraction is padded out to
+        // exactly 28 digits rather than the requested 30.
+        new object[] { "1::numeric(31,30)", 1.0000000000000000000000000000M },
+
+        new object[] { "-12345678901234567890123456.5::numeric(30,1)", -12345678901234567890123456.5M },
+        new object[] { "-12345678901234567890123456::numeric(30,3)", -12345678901234567890123456.000M },
+        new object[] { "12345678901234567890123456::numeric(30,0)", 12345678901234567890123456M },
     };
 
     [Test]


### PR DESCRIPTION
Normalize fractional digits in NumericHandler.ReadRounded to match Postgres scale

Refactors ReadRounded to use StringBuilder directly and adds NormalizeFractionalDigits method to ensure the parsed decimal's scale exactly matches the dscale reported by Postgres. Handles padding when fraction is shorter than scale, trimming excess zero padding when scale <= MaxDecimalScale, and capping scale at MaxDecimalScale (28) for wider numerics.